### PR TITLE
Add IFC export configuration file support

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -9,7 +9,8 @@
   "exportSettings": {
     "exportIfc": true,
     "exportNwc": true,
-    "exportDwg": true
+    "exportDwg": true,
+    "ifcExportConfigPath": "C:\\ProgramData\\GeolocationAddin\\ifc-export-config.json"
   },
   "fuzzyMatchSettings": {
     "enabled": true,

--- a/config/ifc-export-config.sample.json
+++ b/config/ifc-export-config.sample.json
@@ -1,0 +1,15 @@
+{
+  "IFCVersion": "IFC4RV",
+  "SpaceBoundaries": 1,
+  "ExportBaseQuantities": true,
+  "SplitWallsAndColumns": false,
+  "Export2DElements": false,
+  "ExportInternalRevitPropertySets": false,
+  "ExportIFCCommonPropertySets": true,
+  "ExportSchedulesAsPsets": false,
+  "ExportLinkedFiles": false,
+  "IncludeSiteElevation": true,
+  "StoreIFCGUID": true,
+  "UseActiveViewGeometry": true,
+  "TessellationLevelOfDetail": "0.5"
+}

--- a/installer/GeolocationAddin.iss
+++ b/installer/GeolocationAddin.iss
@@ -39,6 +39,7 @@ Source: "{#BuildOutput}\Newtonsoft.Json.dll"; DestDir: "{app}"; Flags: ignorever
 ; Sample config files -> ProgramData (don't overwrite existing)
 Source: "{#ConfigSamples}\config.sample.json"; DestDir: "{commonappdata}\GeolocationAddin"; DestName: "config.json"; Flags: onlyifdoesntexist uninsneveruninstall
 Source: "{#ConfigSamples}\mapping.sample.csv"; DestDir: "{commonappdata}\GeolocationAddin"; DestName: "mapping.csv"; Flags: onlyifdoesntexist uninsneveruninstall
+Source: "{#ConfigSamples}\ifc-export-config.sample.json"; DestDir: "{commonappdata}\GeolocationAddin"; DestName: "ifc-export-config.json"; Flags: onlyifdoesntexist uninsneveruninstall
 
 [Dirs]
 Name: "{commonappdata}\GeolocationAddin"; Flags: uninsneveruninstall

--- a/src/GeolocationAddin/Config/AddinConfig.cs
+++ b/src/GeolocationAddin/Config/AddinConfig.cs
@@ -42,6 +42,9 @@ namespace GeolocationAddin.Config
 
         [JsonProperty("exportDwg")]
         public bool ExportDwg { get; set; } = true;
+
+        [JsonProperty("ifcExportConfigPath")]
+        public string IfcExportConfigPath { get; set; }
     }
 
     public class FuzzyMatchSettings

--- a/src/GeolocationAddin/Config/ConfigLoader.cs
+++ b/src/GeolocationAddin/Config/ConfigLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using GeolocationAddin.Helpers;
 using Newtonsoft.Json;
 
 namespace GeolocationAddin.Config
@@ -42,6 +43,10 @@ namespace GeolocationAddin.Config
                 if (string.IsNullOrWhiteSpace(config.IfcOutputFolder))
                     throw new ConfigurationException("ifcOutputFolder is required when IFC export is enabled.");
                 EnsureDirectory(config.IfcOutputFolder, "ifcOutputFolder");
+
+                if (!string.IsNullOrWhiteSpace(config.ExportSettings.IfcExportConfigPath) &&
+                    !File.Exists(config.ExportSettings.IfcExportConfigPath))
+                    LogHelper.Info($"Warning: ifcExportConfigPath not found, IFC export will use defaults: {config.ExportSettings.IfcExportConfigPath}");
             }
 
             if (config.ExportSettings.ExportNwc)

--- a/src/GeolocationAddin/Core/GeolocationWorkflow.cs
+++ b/src/GeolocationAddin/Core/GeolocationWorkflow.cs
@@ -389,7 +389,7 @@ namespace GeolocationAddin.Core
                 var baseName = Path.GetFileNameWithoutExtension(targetFileName);
 
                 if (_config.ExportSettings.ExportIfc)
-                    result.IfcExported = ModelExporter.ExportIfc(exportDoc, resolvedIfcFolder, baseName, linkInfo.ExportViewName);
+                    result.IfcExported = ModelExporter.ExportIfc(exportDoc, resolvedIfcFolder, baseName, linkInfo.ExportViewName, _config.ExportSettings.IfcExportConfigPath);
 
                 if (_config.ExportSettings.ExportNwc)
                     result.NwcExported = ModelExporter.ExportNwc(exportDoc, resolvedNwcFolder, baseName, linkInfo.ExportViewName);

--- a/src/GeolocationAddin/Core/ModelExporter.cs
+++ b/src/GeolocationAddin/Core/ModelExporter.cs
@@ -30,7 +30,7 @@ namespace GeolocationAddin.Core
                 .FirstOrDefault(v => !v.IsTemplate);
         }
 
-        public static bool ExportIfc(Document doc, string outputFolder, string fileNameWithoutExtension, string exportViewName = null)
+        public static bool ExportIfc(Document doc, string outputFolder, string fileNameWithoutExtension, string exportViewName = null, string ifcExportConfigPath = null)
         {
             try
             {
@@ -43,6 +43,8 @@ namespace GeolocationAddin.Core
                     var view3d = Find3DView(doc, exportViewName);
                     if (view3d != null)
                         options.FilterViewId = view3d.Id;
+
+                    IfcConfigLoader.ApplyConfigFile(options, ifcExportConfigPath);
 
                     doc.Export(outputFolder, fileNameWithoutExtension, options);
 

--- a/src/GeolocationAddin/Helpers/IfcConfigLoader.cs
+++ b/src/GeolocationAddin/Helpers/IfcConfigLoader.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json.Linq;
+
+namespace GeolocationAddin.Helpers
+{
+    public static class IfcConfigLoader
+    {
+        // Metadata properties that should not be passed through AddOption
+        private static readonly HashSet<string> SkipProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Name", "VisibleElementsOfCurrentView"
+        };
+
+        public static void ApplyConfigFile(IFCExportOptions options, string configPath)
+        {
+            if (string.IsNullOrWhiteSpace(configPath))
+                return;
+
+            if (!File.Exists(configPath))
+            {
+                LogHelper.Info($"IFC export config file not found, using defaults: {configPath}");
+                return;
+            }
+
+            try
+            {
+                var json = File.ReadAllText(configPath);
+                var config = JObject.Parse(json);
+
+                LogHelper.Info($"Applying IFC export config from: {configPath}");
+                ApplyConfig(options, config);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error($"Failed to apply IFC export config, using defaults: {ex.Message}");
+            }
+        }
+
+        private static void ApplyConfig(IFCExportOptions options, JObject config)
+        {
+            foreach (var property in config.Properties())
+            {
+                var name = property.Name;
+
+                if (SkipProperties.Contains(name))
+                    continue;
+
+                try
+                {
+                    if (string.Equals(name, "IFCVersion", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var version = ParseIfcVersion(property.Value.ToString());
+                        if (version.HasValue)
+                            options.FileVersion = version.Value;
+                        else
+                            LogHelper.Info($"Unknown IFC version '{property.Value}', skipping.");
+                    }
+                    else if (string.Equals(name, "SpaceBoundaries", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (int.TryParse(property.Value.ToString(), out var level))
+                            options.SpaceBoundaryLevel = level;
+                    }
+                    else if (string.Equals(name, "ExportBaseQuantities", StringComparison.OrdinalIgnoreCase))
+                    {
+                        options.ExportBaseQuantities = GetBool(property.Value);
+                    }
+                    else if (string.Equals(name, "SplitWallsAndColumns", StringComparison.OrdinalIgnoreCase))
+                    {
+                        options.WallAndColumnSplitting = GetBool(property.Value);
+                    }
+                    else
+                    {
+                        // Pass through as string via AddOption
+                        var value = FormatValue(property.Value);
+                        options.AddOption(name, value);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Info($"Skipping IFC config property '{name}': {ex.Message}");
+                }
+            }
+        }
+
+        private static IFCVersion? ParseIfcVersion(string value)
+        {
+            // Try enum parse first (e.g. "IFC4")
+            if (Enum.TryParse<IFCVersion>(value, true, out var version))
+                return version;
+
+            // Common string mappings from Revit's IFC exporter config
+            switch (value.ToUpperInvariant())
+            {
+                case "IFC2X3":
+                case "IFC 2X3":
+                    return IFCVersion.IFC2x3;
+                case "IFC2X3CV2.0":
+                case "IFC2X3 COORDINATION VIEW 2.0":
+                    return IFCVersion.IFC2x3CV2;
+                case "IFC4":
+                case "IFC 4":
+                    return IFCVersion.IFC4;
+                case "IFC4RV":
+                case "IFC4 REFERENCE VIEW":
+                    return IFCVersion.IFC4RV;
+                case "IFC4DTV":
+                case "IFC4 DESIGN TRANSFER VIEW":
+                    return IFCVersion.IFC4DTV;
+                default:
+                    return null;
+            }
+        }
+
+        private static bool GetBool(JToken token)
+        {
+            if (token.Type == JTokenType.Boolean)
+                return token.Value<bool>();
+
+            return string.Equals(token.ToString(), "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string FormatValue(JToken token)
+        {
+            if (token.Type == JTokenType.Boolean)
+                return token.Value<bool>() ? "true" : "false";
+
+            return token.ToString();
+        }
+    }
+}

--- a/src/GeolocationAddin/UI/LinkMappingWindow.xaml
+++ b/src/GeolocationAddin/UI/LinkMappingWindow.xaml
@@ -210,6 +210,21 @@
                                               Checked="ExportCheck_Changed" Unchecked="ExportCheck_Changed"/>
                                     <CheckBox x:Name="ExportDwgCheck" Content="Export DWG" Margin="0,2"
                                               Checked="ExportCheck_Changed" Unchecked="ExportCheck_Changed"/>
+
+                                    <Grid Margin="0,6,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="120"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="IFC Config File:"
+                                                   VerticalAlignment="Center" Margin="0,2"/>
+                                        <TextBox Grid.Column="1" x:Name="IfcExportConfigPathBox"
+                                                 Height="24" Margin="0,2" VerticalContentAlignment="Center"/>
+                                        <Button Grid.Column="2" Content="..."
+                                                Width="30" Margin="4,2,0,2"
+                                                Click="BrowseIfcConfigPath_Click"/>
+                                    </Grid>
                                 </StackPanel>
                             </GroupBox>
 

--- a/src/GeolocationAddin/UI/LinkMappingWindow.xaml.cs
+++ b/src/GeolocationAddin/UI/LinkMappingWindow.xaml.cs
@@ -243,6 +243,7 @@ namespace GeolocationAddin.UI
             ExportIfcCheck.IsChecked = _config.ExportSettings.ExportIfc;
             ExportNwcCheck.IsChecked = _config.ExportSettings.ExportNwc;
             ExportDwgCheck.IsChecked = _config.ExportSettings.ExportDwg;
+            IfcExportConfigPathBox.Text = _config.ExportSettings.IfcExportConfigPath ?? "";
 
             FuzzyEnabledCheck.IsChecked = _config.FuzzyMatchSettings.Enabled;
             TokenThresholdSlider.Value = _config.FuzzyMatchSettings.TokenOverlapThreshold;
@@ -263,6 +264,7 @@ namespace GeolocationAddin.UI
             _config.ExportSettings.ExportIfc = ExportIfcCheck.IsChecked == true;
             _config.ExportSettings.ExportNwc = ExportNwcCheck.IsChecked == true;
             _config.ExportSettings.ExportDwg = ExportDwgCheck.IsChecked == true;
+            _config.ExportSettings.IfcExportConfigPath = string.IsNullOrWhiteSpace(IfcExportConfigPathBox.Text) ? null : IfcExportConfigPathBox.Text.Trim();
 
             _config.FuzzyMatchSettings.Enabled = FuzzyEnabledCheck.IsChecked == true;
             _config.FuzzyMatchSettings.TokenOverlapThreshold = TokenThresholdSlider.Value;
@@ -272,6 +274,7 @@ namespace GeolocationAddin.UI
         private void UpdateExportFieldStates()
         {
             IfcOutputFolderBox.IsEnabled = ExportIfcCheck.IsChecked == true;
+            IfcExportConfigPathBox.IsEnabled = ExportIfcCheck.IsChecked == true;
             NwcOutputFolderBox.IsEnabled = ExportNwcCheck.IsChecked == true;
             DwgOutputFolderBox.IsEnabled = ExportDwgCheck.IsChecked == true;
         }
@@ -296,6 +299,18 @@ namespace GeolocationAddin.UI
                 MessageBox.Show($"Failed to save settings:\n\n{ex.Message}",
                     "Save Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
+        }
+
+        private void BrowseIfcConfigPath_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new OpenFileDialog
+            {
+                Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+                Title = "Select IFC Export Configuration File"
+            };
+
+            if (dialog.ShowDialog() == true)
+                IfcExportConfigPathBox.Text = dialog.FileName;
         }
 
         private void BrowseCsvPath_Click(object sender, RoutedEventArgs e)

--- a/src/GeolocationAddin/UI/SettingsWindow.xaml
+++ b/src/GeolocationAddin/UI/SettingsWindow.xaml
@@ -98,6 +98,20 @@
                                   Checked="ExportCheck_Changed" Unchecked="ExportCheck_Changed"/>
                         <CheckBox x:Name="ExportDwgCheck" Content="Export DWG" Margin="0,2"
                                   Checked="ExportCheck_Changed" Unchecked="ExportCheck_Changed"/>
+
+                        <Grid Margin="0,6,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="IFC Config File:"
+                                       VerticalAlignment="Center" Margin="0,2"/>
+                            <TextBox Grid.Column="1" x:Name="IfcExportConfigPathBox"
+                                     Height="24" Margin="0,2" VerticalContentAlignment="Center"/>
+                            <Button Grid.Column="2" Style="{StaticResource BrowseButton}"
+                                    Click="BrowseIfcConfigPath_Click"/>
+                        </Grid>
                     </StackPanel>
                 </GroupBox>
 

--- a/src/GeolocationAddin/UI/SettingsWindow.xaml.cs
+++ b/src/GeolocationAddin/UI/SettingsWindow.xaml.cs
@@ -35,6 +35,7 @@ namespace GeolocationAddin.UI
             ExportIfcCheck.IsChecked = _config.ExportSettings.ExportIfc;
             ExportNwcCheck.IsChecked = _config.ExportSettings.ExportNwc;
             ExportDwgCheck.IsChecked = _config.ExportSettings.ExportDwg;
+            IfcExportConfigPathBox.Text = _config.ExportSettings.IfcExportConfigPath ?? "";
 
             FuzzyEnabledCheck.IsChecked = _config.FuzzyMatchSettings.Enabled;
             TokenThresholdSlider.Value = _config.FuzzyMatchSettings.TokenOverlapThreshold;
@@ -55,6 +56,7 @@ namespace GeolocationAddin.UI
             _config.ExportSettings.ExportIfc = ExportIfcCheck.IsChecked == true;
             _config.ExportSettings.ExportNwc = ExportNwcCheck.IsChecked == true;
             _config.ExportSettings.ExportDwg = ExportDwgCheck.IsChecked == true;
+            _config.ExportSettings.IfcExportConfigPath = string.IsNullOrWhiteSpace(IfcExportConfigPathBox.Text) ? null : IfcExportConfigPathBox.Text.Trim();
 
             _config.FuzzyMatchSettings.Enabled = FuzzyEnabledCheck.IsChecked == true;
             _config.FuzzyMatchSettings.TokenOverlapThreshold = TokenThresholdSlider.Value;
@@ -64,6 +66,7 @@ namespace GeolocationAddin.UI
         private void UpdateExportFieldStates()
         {
             IfcOutputFolderBox.IsEnabled = ExportIfcCheck.IsChecked == true;
+            IfcExportConfigPathBox.IsEnabled = ExportIfcCheck.IsChecked == true;
             NwcOutputFolderBox.IsEnabled = ExportNwcCheck.IsChecked == true;
             DwgOutputFolderBox.IsEnabled = ExportDwgCheck.IsChecked == true;
         }
@@ -83,6 +86,18 @@ namespace GeolocationAddin.UI
 
             if (dialog.ShowDialog() == true)
                 CsvMappingPathBox.Text = dialog.FileName;
+        }
+
+        private void BrowseIfcConfigPath_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new OpenFileDialog
+            {
+                Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+                Title = "Select IFC Export Configuration File"
+            };
+
+            if (dialog.ShowDialog() == true)
+                IfcExportConfigPathBox.Text = dialog.FileName;
         }
 
         private void BrowseFolder_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Allow users to point to a Revit IFC export config JSON file to control IFC version, property sets, base quantities, and other export settings instead of using bare defaults. The add-in reads the JSON and applies settings to IFCExportOptions at export time, with graceful fallback to defaults on missing/invalid files.